### PR TITLE
fix: Replace related video components in Detail Page

### DIFF
--- a/src/api/FakeYoutubeApi.js
+++ b/src/api/FakeYoutubeApi.js
@@ -24,9 +24,11 @@ export async function VideoComment() {
 export async function videoDataInfo() {
   return axios.get(`/data/hyewonTest.json`).then((res) => res.data.items[0]);
 }
-// export async function relatedVideoList() {
-//   return axios.get(`/data/relatedVideoList.json`).then((res) => res.data.items);
-// }
+
+export async function relatedVideo() {
+  return axios.get(`/data/relatedVideoList.json`).then((res) => res.data.items);
+}
+
 // export async function videoDetailInfo() {
 //   return axios.get(`/data/videoInfo.json`).then((res) => res.data.items);
 // }

--- a/src/components/RelatedVideoInVideoDetail/RelatedVideoInVideoDetail.jsx
+++ b/src/components/RelatedVideoInVideoDetail/RelatedVideoInVideoDetail.jsx
@@ -4,6 +4,9 @@ import VideoInfo from './videoInfo.json';
 import styles from './RelatedVideoInVideoDetail.module.scss';
 import { format, register } from 'timeago.js';
 import koLocale from 'timeago.js/lib/lang/ko';
+import { useQuery } from '@tanstack/react-query';
+import { relatedVideo } from '../../api/FakeYoutubeApi';
+import VideoCard from '../VideoCard/VideoCard';
 
 register('ko', koLocale);
 const formatDuration = (duration) => {
@@ -18,38 +21,53 @@ const formatDuration = (duration) => {
   }
   return output;
 };
-const RelatedVideoInVideoDetail = () => {
+
+const RelatedVideoInVideoDetail = ({ id }) => {
+  const { isLoading, data: videos } = useQuery(['related', id], () => relatedVideo(id), { staleTime: 1000 * 60 * 5 });
+
+  if (isLoading) return;
+
   return (
-    <div className={styles.relatedVideoContainer}>
-      <ul className={styles.relatedList}>
-        {RelatedVideo.items.map((item, i) => {
-          return (
-            <li key={item.etag} className={styles.videoCard}>
-              <a href={item.id}>
-                {/* 썸네일과 영상 길이 */}
-                <div className={styles.videoPreviewContainer}>
-                  <img src={item.snippet.thumbnails.default.url} />
-                  <div className={styles.videoDuration}>
-                    {formatDuration(VideoInfo?.items[i]?.contentDetails?.duration)}
-                  </div>
-                </div>
-                {/* 영상 제목, 채널 이름, 조회수, 올린 시간 */}
-                <div className={styles.videoInfoContainer}>
-                  <h3>{item.snippet.title}</h3>
-                  <div className={styles.channelName}>{item.snippet.channelTitle}</div>
-                  <div className={styles.videoMetaData}>
-                    <span className={styles.videoViewPoint}>{VideoInfo?.items[i]?.statistics?.viewCount} views </span>
-                    <span> • </span>
-                    <span>{format(VideoInfo?.items[i]?.snippet?.publishedAt, 'ko')}</span>
-                  </div>
-                </div>
-              </a>
-            </li>
-          );
-        })}
-      </ul>
-    </div>
+    <>
+      {videos.map((video) => (
+        <VideoCard key={video.id} video={video} type="list" />
+      ))}
+    </>
   );
 };
 
 export default RelatedVideoInVideoDetail;
+
+// const RelatedVideoInVideoDetail = () => {
+//   return (
+//     <div className={styles.relatedVideoContainer}>
+//       <ul className={styles.relatedList}>
+//         {RelatedVideo.items.map((item, i) => {
+//           return (
+//             <li key={item.etag} className={styles.videoCard}>
+//               <a href={item.id}>
+//                 {/* 썸네일과 영상 길이 */}
+//                 <div className={styles.videoPreviewContainer}>
+//                   <img src={item.snippet.thumbnails.default.url} />
+//                   <div className={styles.videoDuration}>
+//                     {formatDuration(VideoInfo?.items[i]?.contentDetails?.duration)}
+//                   </div>
+//                 </div>
+//                 {/* 영상 제목, 채널 이름, 조회수, 올린 시간 */}
+//                 <div className={styles.videoInfoContainer}>
+//                   <h3>{item.snippet.title}</h3>
+//                   <div className={styles.channelName}>{item.snippet.channelTitle}</div>
+//                   <div className={styles.videoMetaData}>
+//                     <span className={styles.videoViewPoint}>{VideoInfo?.items[i]?.statistics?.viewCount} views </span>
+//                     <span> • </span>
+//                     <span>{format(VideoInfo?.items[i]?.snippet?.publishedAt, 'ko')}</span>
+//                   </div>
+//                 </div>
+//               </a>
+//             </li>
+//           );
+//         })}
+//       </ul>
+//     </div>
+//   );
+// };

--- a/src/components/VideoCard/VideoCard.jsx
+++ b/src/components/VideoCard/VideoCard.jsx
@@ -8,15 +8,17 @@ import PlayVideo from '../PlayVideo/PlayVideo';
 import HoverButton from '../HoverButton/HoverButton';
 import { RxDotsVertical } from 'react-icons/rx';
 
-export default function VideoCard({ video }) {
+export default function VideoCard({ video, type }) {
   const { title, thumbnails, channelTitle, publishedAt, description, channelId } = video.snippet;
   const [videoHover, setVideoHover] = useState(false);
   const [playVideo, setPlayVideo] = useState(false);
-
   const [listOpen, setListOpen] = useState(false);
 
   const { videoId } = video.id;
+
   const navigate = useNavigate();
+
+  const isList = type === 'list';
 
   let timer;
 
@@ -34,16 +36,13 @@ export default function VideoCard({ video }) {
   };
 
   const goToDetailPage = (event) => {
-    // 클릭 시, 해당 동영상으로 이동 및 video 정보 state로 전달
-    // state로 video 정보를 전달할 경우,
-    // 클릭했을때만 정보가 전달 되고 수기로 주소를 직접 작성할 땐 데이터가 전달이 되지 않으니 주의할 것!
     if (event.target.dataset.name !== 'button' && event.target.dataset.name !== 'icon')
       navigate(`/watch/${video.id.videoId}`, { state: { video: video } });
   };
 
   return (
     <li className={styles.video} onClick={goToDetailPage} onMouseOver={handleMouseHover} onMouseOut={handleMouseOut}>
-      <VideoThumbnail id={videoId} url={thumbnails.medium.url} title={title} videoHover={videoHover} />
+      <VideoThumbnail id={videoId} url={thumbnails.medium.url} title={title} videoHover={videoHover} isList={isList} />
       {videoHover && <PlayVideo id={videoId} videoHover={videoHover} />}
       <div className={styles.video_info}>
         <div className={styles.video_info_setting}>
@@ -57,7 +56,7 @@ export default function VideoCard({ video }) {
         </div>
         <VideoStatistics id={videoId} publishedAt={publishedAt} />
         <ChannelInfo channelId={channelId} title={channelTitle} />
-        <p className={styles.description}>{description}</p>
+        {isList ? null : <p className={styles.description}>{description}</p>}
       </div>
     </li>
   );

--- a/src/components/VideoCard/VideoCard.module.scss
+++ b/src/components/VideoCard/VideoCard.module.scss
@@ -4,6 +4,7 @@
   margin-bottom: 1rem;
   gap: 1.5rem;
   color: var(--color-white);
+  overflow-x: hidden;
 
   .video_img {
     border-radius: 10px;
@@ -39,6 +40,8 @@
       color: var(--color-light-gray);
       font-size: 0.9rem;
       margin-bottom: 1.1rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   }
 }

--- a/src/components/VideoThumbnail/VideoThumbnail.jsx
+++ b/src/components/VideoThumbnail/VideoThumbnail.jsx
@@ -9,7 +9,6 @@ export default function VideoThumbnail({ id, url, title }) {
   if (isLoading) return;
   const { duration } = contentInfo;
 
-  // console.log('contentInfo::::', contentInfo);
   return (
     <div className={styles.thumbnail}>
       <img className={styles.img} src={url} alt={title} />

--- a/src/pages/VideoDetail/VideoDetail.jsx
+++ b/src/pages/VideoDetail/VideoDetail.jsx
@@ -10,18 +10,18 @@ const VideoDetail = () => {
   const {
     state: { video },
   } = useLocation();
-  // console.log(video.id.videoId);
+
   const { title, channelTitle, description, publishedAt } = video.snippet;
 
   return (
     <div className={styles.detailPage}>
-      <div className="column1">
+      <div className={styles.column1}>
         <Player id={video.id.videoId} />
         <VideoInfo title={title} channelTitle={channelTitle} description={description} publishedAt={publishedAt} />
         <Comments videoId={video.id.videoId} />
       </div>
-      <div className="column2">
-        <RelatedVideoInVideoDetail />
+      <div className={styles.column2}>
+        <RelatedVideoInVideoDetail id={video.id.videoId} />
       </div>
     </div>
   );

--- a/src/pages/VideoDetail/VideoDetail.module.scss
+++ b/src/pages/VideoDetail/VideoDetail.module.scss
@@ -1,11 +1,15 @@
 .detailPage {
   display: flex;
   background-color: var(--color-black);
+  // overflow-x: hidden;
+
   .column1 {
-    width: 80%;
+    width: 70%;
+    margin: 0 2rem;
   }
   .column2 {
-    // margin-left: 20px;
-    width: 20%;
+    width: 30%;
+    margin-top: 1rem;
+    margin-right: 2rem;
   }
 }


### PR DESCRIPTION
## ✔️ 체크사항

- [ ] 가장 최근 merge를 pull 받고 진행하는 것이 맞나요? 👉[최근 pr 확인 링크](https://github.com/react-toyproject-team5/react-youtube-clone/pulls?q=is%3Apr+is%3Aclosed)👈
- [ ] merge 하는 곳이 develop 브랜치가 맞나요?
- [ ] 노션 진행상황 및 라이브러리 업데이트를 진행했나요? 👉[노션 진행상황](https://www.notion.so/1cfe09da512544fa8a3456d82ae3ead9?v=d4e172e861894c86a7f96c971bf6e5f1) / [노션 라이브러리](https://www.notion.so/e8afec87227a4e5283b0a6397ed62f6c)👈

## 🔊 팀원들에게 알릴 사항

- 영상상세페이지에서 관련영상 VideoCard 컴포넌트로 교체 했는데, VideoCard의 내부 컴포넌트들이 안보이는 현상 발생

## 🌐 담당 구역 작업

[검색페이지]

- VideoCard 컴포넌트 type 추가

## 🌐 담당 이외 작업

[상세페이지]

- 관련영상 VideoCard 컴포넌트로 교체

